### PR TITLE
JudithBranch

### DIFF
--- a/FORWARD/DA.m
+++ b/FORWARD/DA.m
@@ -1,28 +1,19 @@
 classdef DA <handle
-    % super class of data assimilation subclass
-    % methods and functions shared by the subclass of DA
+    % this is an abstract interface class for data assimilation subclass
+    % list all properties and functions shared by the concrete subclass of DA
     properties
-        method = 'CSKF';
-        m = [];
-        kernel = []; % kernel
-        fwcase = []; % instance of model
-        obsstd = []; % standard deviation of observation
-    end
-    
-    methods
-        function da1 = DA(obj,case1,param)
-            % constructor: copy parameters from user specified param
-            % da1 is an instance of DA superclass
-            obj.method = param.method;
-            obj.kernel = param.kernel;
-            obj.obsstd = 0.4*ones(case1.n,1);
-            switch obj.method
-                case KF
-                    da1 = KF(case1); % illegal
-                otherwise %add your own method class
-                    error('method does not exit');
-            end
-        end
+        n; % number of measurements
+        m; % number of unknowns
+        kernel; % kernel, a function handle
+        x; % state mean
+        nt; % total assimilation step
+        K; % Kalman gain
+        t_assim; % assimilation step count
+        t_forecast;% forecast step count    
+    end    
+    methods (Abstract)
+        predict(obj,fw);
+        update(obj,fw,z);
     end
     
 end

--- a/FORWARD/FW.m
+++ b/FORWARD/FW.m
@@ -1,6 +1,6 @@
 classdef FW <handle
-    % Forward model superclass
-    % Methods and functions shared in the FW subclass
+    % Abstract interface for all forward model subclass
+    % list all properties and methods shared in the FW subclass (concrete)
     properties
         model = '';
         m = [];
@@ -10,16 +10,8 @@ classdef FW <handle
         x = [];
         loc = [];
     end
-    
-    methods
-        function obj = FW(param)
-            % obj is an instance of FW class
-            obj.model = param.model;
-            switch obj.model
-                case Saetrom
-                    obj = Saetrom(); % illegal
-                otherwise %add your own class
-            end
-        end
+    methods (Abstract)
+        y = h(obj,x); % measurement function
+        x = f(obj,x); % forward model
     end
 end


### PR DESCRIPTION
- List all common properties and methods but without the need to
  implement them in the superclass
- this will affect the subclass definition
  e.g., use CSKF < DA
- avoid redefine properties belong to the Abstract class in the subclass
- must implement the Abstract methods list in the methods (Abstract)
  section
- TODO: include selectDA and selectFW as method in the superclass?
